### PR TITLE
Data converter

### DIFF
--- a/converter/convertdata.js
+++ b/converter/convertdata.js
@@ -15,8 +15,15 @@ function process_data() {
 }
 
 function format_text(sep,header) {
-  text = document.getElementById('data_input');
-  line_split = text.value.split("\n");
+  input = document.getElementById('data_input');
+  placeholder = "%%%%";
+  if (/%/.test(sep)) {
+    placeholder = "####";
+  }
+  escape = new RegExp("\\\\" + sep, "g");
+  unescape = new RegExp(placeholder, "g");
+  text = input.value.replace(escape, placeholder);
+  line_split = text.split("\n");
   field1 = "name";
   field2 = "image";
   field3 = "description";
@@ -24,21 +31,44 @@ function format_text(sep,header) {
   if (header == true) {
     start_line = 1;
     header_line = line_split[0].split(sep);
-    field1 = header_line[0];
-    field2 = header_line[1];
-    field3 = header_line[2];
+    clean_varname = /[ ,\!@#\$%\^&\*\(\)\-\+=\|;:'"<>\.\?\/]+/g
+    field1 = header_line[0].replace(unescape, sep).replace(clean_varname, "_").replace(/_$/g, "");
+    field2 = header_line[1].replace(unescape, sep).replace(clean_varname, "_").replace(/_$/g, "");
+    field3 = header_line[2].replace(unescape, sep).replace(clean_varname, "_").replace(/_$/g, "");
   }
   result = "var inputstream = [{\n";
   for (i = start_line; i < line_split.length -1; i++) {
     col_split = line_split[i].split(sep);
-    name = col_split[0];
-    image = col_split[1];
-    description = col_split[2];
+    name = col_split[0].replace(unescape, sep);
+    image = col_split[1].replace(unescape, sep);
+    description = col_split[2].replace(unescape, sep);
     if (i == line_split.length - 2) {
       result += '    "' + field1 + '": "' + name + '",\n    "' + field2 + '": "' + image + '",\n    "' + field3 + '": "' + description + '"\n'
     } else {
       result += '    "' + field1 + '": "' + name + '",\n    "' + field2 + '": "' + image + '",\n    "' + field3 + '": "' + description + '"\n  }, {\n'
     }
   }
-  text.value = result + "}];\n";
+  input.value = result + "}];\n";
+}
+
+function sample_data() {
+  text = document.getElementById('data_input');
+  header = "name\timage\tdescription\n";
+  data = "Dhow\thttps://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Dhow_znz.jpg/300px-Dhow_znz.jpg\tA heavy ship, the traditional deep-sea dhow.\nBoum\thttps://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Sd11-boom.JPG/220px-Sd11-boom.JPG\tA large-sized dhow with a stern that is tapering in shape and a more symmetrical overall structure.\nJahazi\thttps://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Jahazi.jpg/300px-Jahazi.jpg\tA fishing or trading dhow with a broad hull similar to the Jalibut.\nPattamar\thttps://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Boutre_indien.jpg/220px-Boutre_indien.jpg\tA type of Indian dhow.\nSambuk\thttps://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Dhau.jpg/220px-Dhau.jpg\tThe largest type of dhow seen in the Persian Gulf today.\n";
+
+  f = document.getElementsByName("format");
+  if (f[1].checked) {
+    header = header.replace(/\t/g, ",");
+    data = data.replace(/,/g, "\\,").replace(/\t/g, ",");
+  } else if (f[2].checked) {
+    sep = document.getElementsByName("sep")[0].value;
+    header = header.replace(/\t/g, sep);
+    data = data.replace(/\t/g, sep);
+  }
+  h = document.getElementsByName("header");
+  if (h[0].checked) {
+    text.value = header + data;
+  } else {
+    text.value = data;
+  }
 }

--- a/converter/convertdata.js
+++ b/converter/convertdata.js
@@ -22,7 +22,7 @@ function format_text(sep,header) {
   }
   escape = new RegExp("\\\\" + sep, "g");
   unescape = new RegExp(placeholder, "g");
-  text = input.value.replace(escape, placeholder);
+  text = input.value.replace(escape, placeholder).replace(/\n*$/g, "\n");
   line_split = text.split("\n");
   field1 = "name";
   field2 = "image";

--- a/converter/convertdata.js
+++ b/converter/convertdata.js
@@ -72,3 +72,8 @@ function sample_data() {
     text.value = data;
   }
 }
+
+function check_other() {
+  f = document.getElementsByName("format");
+  f[2].checked = true;
+}

--- a/converter/convertdata.js
+++ b/converter/convertdata.js
@@ -22,31 +22,42 @@ function format_text(sep,header) {
   }
   escape = new RegExp("\\\\" + sep, "g");
   unescape = new RegExp(placeholder, "g");
-  text = input.value.replace(escape, placeholder).replace(/\n*$/g, "\n");
+  text = input.value.replace(escape, placeholder).replace(/\n*$/, "");
   line_split = text.split("\n");
-  field1 = "name";
-  field2 = "image";
-  field3 = "description";
+  field_number = 1;
   start_line = 0;
+  header_names = [];
+  header_line = line_split[0].split(sep);
   if (header == true) {
     start_line = 1;
-    header_line = line_split[0].split(sep);
-    clean_varname = /[ ,\!@#\$%\^&\*\(\)\-\+=\|;:'"<>\.\?\/]+/g
-    field1 = header_line[0].replace(unescape, sep).replace(clean_varname, "_").replace(/_$/g, "");
-    field2 = header_line[1].replace(unescape, sep).replace(clean_varname, "_").replace(/_$/g, "");
-    field3 = header_line[2].replace(unescape, sep).replace(clean_varname, "_").replace(/_$/g, "");
+    clean_varname = /[ ,\!@#\$%\^&\*\(\)\-\+=\|;:'"<>\.\?\/]+/g;
+    for (i = 0; i < header_line.length; i++) {
+      varname = header_line[i].replace(unescape, sep).replace(clean_varname, "_").replace(/_$/g, "");
+      header_names.push(varname);
+    }
+  } else {
+    for (i = 1; i < header_line.length + 1; i++) {
+      varname = "field" + i;
+      header_names.push(varname);
+    }
   }
   result = "var inputstream = [{\n";
-  for (i = start_line; i < line_split.length -1; i++) {
+  for (i = start_line; i < line_split.length; i++) {
     col_split = line_split[i].split(sep);
-    name = col_split[0].replace(unescape, sep);
-    image = col_split[1].replace(unescape, sep);
-    description = col_split[2].replace(unescape, sep);
-    if (i == line_split.length - 2) {
-      result += '    "' + field1 + '": "' + name + '",\n    "' + field2 + '": "' + image + '",\n    "' + field3 + '": "' + description + '"\n'
-    } else {
-      result += '    "' + field1 + '": "' + name + '",\n    "' + field2 + '": "' + image + '",\n    "' + field3 + '": "' + description + '"\n  }, {\n'
+    result_line = '    "';
+    for (n = 0; n < col_split.length; n++) {
+      field_name = header_names[n];
+      field_data = col_split[n].replace(unescape, sep);
+      line_ending = '",\n    "';
+      if (n == col_split.length - 1) {
+        line_ending = '"\n  }, {\n';
+        if (i == line_split.length - 1) {
+          line_ending = '"\n';
+        }
+      }
+      result_line += field_name + '": "' + field_data + line_ending;
     }
+    result += result_line;
   }
   input.value = result + "}];\n";
 }

--- a/converter/convertdata.js
+++ b/converter/convertdata.js
@@ -1,0 +1,44 @@
+function process_data() {
+  header = false;
+  sep = "\t";
+  f = document.getElementsByName("format");
+  if (f[1].checked) {
+    sep = ",";
+  } else if (f[2].checked) {
+    sep = document.getElementsByName("sep")[0].value;
+  }
+  h = document.getElementsByName("header");
+  if (h[0].checked) {
+    header = true;
+  }
+  format_text(sep, header);
+}
+
+function format_text(sep,header) {
+  text = document.getElementById('data_input');
+  line_split = text.value.split("\n");
+  field1 = "name";
+  field2 = "image";
+  field3 = "description";
+  start_line = 0;
+  if (header == true) {
+    start_line = 1;
+    header_line = line_split[0].split(sep);
+    field1 = header_line[0];
+    field2 = header_line[1];
+    field3 = header_line[2];
+  }
+  result = "var inputstream = [{\n";
+  for (i = start_line; i < line_split.length -1; i++) {
+    col_split = line_split[i].split(sep);
+    name = col_split[0];
+    image = col_split[1];
+    description = col_split[2];
+    if (i == line_split.length - 2) {
+      result += '    "' + field1 + '": "' + name + '",\n    "' + field2 + '": "' + image + '",\n    "' + field3 + '": "' + description + '"\n'
+    } else {
+      result += '    "' + field1 + '": "' + name + '",\n    "' + field2 + '": "' + image + '",\n    "' + field3 + '": "' + description + '"\n  }, {\n'
+    }
+  }
+  text.value = result + "}];\n";
+}

--- a/converter/index.html
+++ b/converter/index.html
@@ -27,6 +27,7 @@
       <textarea id="data_input" rows=25 cols=85 accesskey="t" placeholder="Add text to format here"></textarea><br><br>
 
       <button class="btn btn-default btn-lg" onclick="process_data()" accesskey="f">Format for Jalibut</button>
+      <button class="btn btn-default btn-me" onclick="sample_data()" accesskey="s">Use sample data</button>
 
   </body>
 </html>

--- a/converter/index.html
+++ b/converter/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Jalibut Data Format Conversion Tool</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+    <script type=text/javascript src="convertdata.js"></script>
+  </head>
+  <body>
+    <div class="jumbotron">
+      <div class="container">
+        <h1>Jalibut Data Format Conversion Tool</h1>
+          <h2>Convert raw data into Jalibut JSON objects</h2>
+      </div>
+    </div>
+    <div class="container" style="align:center;">
+      <a href="https://github.com/darshandsoni/jalibut" class="btn btn-default btn-lg">View on GitHub</a>
+      <h3>Given a collection of data separated by tabs, commas or other symbols as input, this converter will return a JSON array suitable for use with <a href="https://github.com/darshandsoni/jalibut">Jalibut</a>.</h3>
+
+      <input type="radio" name="format" value="tsv" checked="checked">TSV <input type="radio" name="format" value="csv">CSV <input type="radio" name="format" value="other">Other... <input type="text" name="sep" size="5" placeholder="Separator"><br>
+      <input type="radio" name="header" value="y">Header row <input type="radio" name="header" value="n" checked="checked">No header row
+
+      <p>
+      <p>
+
+      <textarea id="data_input" rows=25 cols=85 accesskey="t" placeholder="Add text to format here"></textarea><br><br>
+
+      <button class="btn btn-default btn-lg" onclick="process_data()" accesskey="f">Format for Jalibut</button>
+
+  </body>
+</html>

--- a/converter/index.html
+++ b/converter/index.html
@@ -18,7 +18,7 @@
       <a href="https://github.com/darshandsoni/jalibut" class="btn btn-default btn-lg">View on GitHub</a>
       <h3>Given a collection of data separated by tabs, commas or other symbols as input, this converter will return a JSON array suitable for use with <a href="https://github.com/darshandsoni/jalibut">Jalibut</a>.</h3>
 
-      <input type="radio" name="format" value="tsv" checked="checked">TSV <input type="radio" name="format" value="csv">CSV <input type="radio" name="format" value="other">Other... <input type="text" name="sep" size="5" placeholder="Separator"><br>
+      <input type="radio" name="format" value="tsv" checked="checked">TSV <input type="radio" name="format" value="csv">CSV <input type="radio" name="format" value="other">Other... <input type="text" name="sep" size="5" placeholder="Separator" onclick="check_other()" onkeydown="check_other()"><br>
       <input type="radio" name="header" value="y">Header row <input type="radio" name="header" value="n" checked="checked">No header row
 
       <p>

--- a/objects.js
+++ b/objects.js
@@ -1,5 +1,4 @@
 var inputstream = [{
-  "boats": [{
     "name": "Dhow",
     "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Dhow_znz.jpg/300px-Dhow_znz.jpg",
     "description": "A heavy ship, the traditional deep-sea dhow."
@@ -19,5 +18,4 @@ var inputstream = [{
     "name": "Sambuk",
     "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Dhau.jpg/220px-Dhau.jpg",
     "description": "The largest type of dhow seen in the Persian Gulf today."
-  }]
 }];

--- a/quicksearch.js
+++ b/quicksearch.js
@@ -1,7 +1,7 @@
 var i;
 var content = "";
 
-obj = inputstream[0].boats;
+obj = inputstream;
 
 for(i=0;i < obj.length; i++){
   name = obj[i].name;


### PR DESCRIPTION
This adds a tool for converting arbitrary data sets into jalibut format. You can try it out online [here](https://rawgit.com/dohliam/jalibut/data_converter/converter/index.html).

Features:
- the data can be separated by tabs, commas, or whatever you want
- you can specify a header line (in which case field names will be auto-detected)
- there is a sample data button for quick tests (give it a try! :smile: )

Note that this does away with the extraneous "boats" object that is found in objects.js. I'll add one final commit to fix that in jalibut as well.

Bug reports / further feature requests welcome :smile: 
